### PR TITLE
Virtualbox vagrant support changes

### DIFF
--- a/osx107-desktop.json
+++ b/osx107-desktop.json
@@ -61,7 +61,7 @@
       ["modifyvm", "{{.Name}}", "--boot1", "dvd"],
       ["modifyvm", "{{.Name}}", "--boot2", "disk"],
       ["modifyvm", "{{.Name}}", "--chipset", "ich9"],
-      ["modifyvm", "{{.Name}}", "--cpuidset", "00000001", "000306a9", "00020800", "80000201", "178bfbff"],
+      ["modifyvm", "{{.Name}}", "--cpuidset", "00000001", "000006fb", "00000800", "80000209", "078bfbff"],
       ["modifyvm", "{{.Name}}", "--firmware", "efi"],
       ["modifyvm", "{{.Name}}", "--hpet", "on"],
       ["modifyvm", "{{.Name}}", "--keyboard", "usb"],

--- a/osx107.json
+++ b/osx107.json
@@ -59,7 +59,7 @@
       ["modifyvm", "{{.Name}}", "--boot1", "dvd"],
       ["modifyvm", "{{.Name}}", "--boot2", "disk"],
       ["modifyvm", "{{.Name}}", "--chipset", "ich9"],
-      ["modifyvm", "{{.Name}}", "--cpuidset", "00000001", "000306a9", "00020800", "80000201", "178bfbff"],
+      ["modifyvm", "{{.Name}}", "--cpuidset", "00000001", "000006fb", "00000800", "80000209", "078bfbff"],
       ["modifyvm", "{{.Name}}", "--firmware", "efi"],
       ["modifyvm", "{{.Name}}", "--hpet", "on"],
       ["modifyvm", "{{.Name}}", "--keyboard", "usb"],

--- a/script/update.sh
+++ b/script/update.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eux
 
-if [[ $UPDATE  =~ true || $UPDATE =~ 1 || $UPDATE =~ yes ]]; then
+if [[ "$UPDATE" =~ ^(true|yes|on|1|TRUE|YES|ON])$ ]]; then
 
     echo "==> Running software update"
     softwareupdate --install --all -v

--- a/script/update.sh
+++ b/script/update.sh
@@ -1,9 +1,11 @@
 #!/bin/bash -eux
 
-[[ ! $UPDATE ]] && exit
+if [[ $UPDATE  =~ true || $UPDATE =~ 1 || $UPDATE =~ yes ]]; then
 
-echo "==> Running software update"
-softwareupdate --install --all -v
+    echo "==> Running software update"
+    softwareupdate --install --all -v
 
-echo "==> Rebooting the machine"
-reboot
+    echo "==> Rebooting the machine"
+    reboot
+
+fi

--- a/script/xcode-cli-tools.sh
+++ b/script/xcode-cli-tools.sh
@@ -18,13 +18,14 @@ if [ "$OSX_VERS" -ge 9 ]; then
 # https://devimages.apple.com.edgekey.net/downloads/xcode/simulators/index-3905972D-B609-49CE-8D06-51ADC78E07BC.dvtdownloadableindex
 else
     [ "$OSX_VERS" -eq 7 ] && DMGURL=http://devimages.apple.com/downloads/xcode/command_line_tools_for_xcode_os_x_lion_april_2013.dmg
+    [ "$OSX_VERS" -eq 7 ] && ALLOW_UNTRUSTED=-allowUntrusted
     [ "$OSX_VERS" -eq 8 ] && DMGURL=http://devimages.apple.com/downloads/xcode/command_line_tools_for_osx_mountain_lion_april_2014.dmg
 
     TOOLS=clitools.dmg
     curl "$DMGURL" -o "$TOOLS"
     TMPMOUNT=`/usr/bin/mktemp -d /tmp/clitools.XXXX`
     hdiutil attach "$TOOLS" -mountpoint "$TMPMOUNT"
-    installer -pkg "$(find $TMPMOUNT -name '*.mpkg')" -target /
+    installer $ALLOW_UNTRUSTED -pkg "$(find $TMPMOUNT -name '*.mpkg')" -target /
     hdiutil detach "$TMPMOUNT"
     rm -rf "$TMPMOUNT"
     rm "$TOOLS"

--- a/tpl/vagrantfile-osx107-desktop.tpl
+++ b/tpl/vagrantfile-osx107-desktop.tpl
@@ -11,7 +11,7 @@ Vagrant.configure("2") do |config|
       v.customize ["modifyvm", "{{.Name}}", "--boot1", "dvd"]
       v.customize ["modifyvm", "{{.Name}}", "--boot2", "disk"]
       v.customize ["modifyvm", "{{.Name}}", "--chipset", "ich9"]
-      v.customize ["modifyvm", "{{.Name}}", "--cpuidset", "00000001", "000306a9", "00020800", "80000201", "178bfbff"]
+      v.customize ["modifyvm", "{{.Name}}", "--cpuidset", "00000001", "000006fb", "00000800", "80000209", "078bfbff"]
       v.customize ["modifyvm", "{{.Name}}", "--firmware", "efi"]
       v.customize ["modifyvm", "{{.Name}}", "--hpet", "on"]
       v.customize ["modifyvm", "{{.Name}}", "--keyboard", "usb"]

--- a/tpl/vagrantfile-osx107-desktop.tpl
+++ b/tpl/vagrantfile-osx107-desktop.tpl
@@ -7,17 +7,17 @@ Vagrant.configure("2") do |config|
 
     config.vm.provider :virtualbox do |v, override|
       v.gui = true
-      v.customize ["modifyvm", "{{.Name}}", "--audiocontroller", "hda"]
-      v.customize ["modifyvm", "{{.Name}}", "--boot1", "dvd"]
-      v.customize ["modifyvm", "{{.Name}}", "--boot2", "disk"]
-      v.customize ["modifyvm", "{{.Name}}", "--chipset", "ich9"]
-      v.customize ["modifyvm", "{{.Name}}", "--cpuidset", "00000001", "000006fb", "00000800", "80000209", "078bfbff"]
-      v.customize ["modifyvm", "{{.Name}}", "--firmware", "efi"]
-      v.customize ["modifyvm", "{{.Name}}", "--hpet", "on"]
-      v.customize ["modifyvm", "{{.Name}}", "--keyboard", "usb"]
-      v.customize ["modifyvm", "{{.Name}}", "--memory", "2048"]
-      v.customize ["modifyvm", "{{.Name}}", "--mouse", "usbtablet"]
-      v.customize ["modifyvm", "{{.Name}}", "--vram", "9"]
+      v.customize ["modifyvm", :id, "--audiocontroller", "hda"]
+      v.customize ["modifyvm", :id, "--boot1", "dvd"]
+      v.customize ["modifyvm", :id, "--boot2", "disk"]
+      v.customize ["modifyvm", :id, "--chipset", "ich9"]
+      v.customize ["modifyvm", :id, "--cpuidset", "00000001", "000006fb", "00000800", "80000209", "078bfbff"]
+      v.customize ["modifyvm", :id, "--firmware", "efi"]
+      v.customize ["modifyvm", :id, "--hpet", "on"]
+      v.customize ["modifyvm", :id, "--keyboard", "usb"]
+      v.customize ["modifyvm", :id, "--memory", "2048"]
+      v.customize ["modifyvm", :id, "--mouse", "usbtablet"]
+      v.customize ["modifyvm", :id, "--vram", "9"]
     end
 
     ["vmware_fusion", "vmware_workstation"].each do |provider| 

--- a/tpl/vagrantfile-osx108-desktop.tpl
+++ b/tpl/vagrantfile-osx108-desktop.tpl
@@ -7,17 +7,17 @@ Vagrant.configure("2") do |config|
  
     config.vm.provider :virtualbox do |v, override|
       v.gui = true
-      v.customize ["modifyvm", "{{.Name}}", "--audiocontroller", "hda"]
-      v.customize ["modifyvm", "{{.Name}}", "--boot1", "dvd"]
-      v.customize ["modifyvm", "{{.Name}}", "--boot2", "disk"]
-      v.customize ["modifyvm", "{{.Name}}", "--chipset", "ich9"]
-      v.customize ["modifyvm", "{{.Name}}", "--cpuidset", "00000001", "000306a9", "00020800", "80000201", "178bfbff"]
-      v.customize ["modifyvm", "{{.Name}}", "--firmware", "efi"]
-      v.customize ["modifyvm", "{{.Name}}", "--hpet", "on"]
-      v.customize ["modifyvm", "{{.Name}}", "--keyboard", "usb"]
-      v.customize ["modifyvm", "{{.Name}}", "--memory", "2048"]
-      v.customize ["modifyvm", "{{.Name}}", "--mouse", "usbtablet"]
-      v.customize ["modifyvm", "{{.Name}}", "--vram", "9"]
+      v.customize ["modifyvm", :id, "--audiocontroller", "hda"]
+      v.customize ["modifyvm", :id, "--boot1", "dvd"]
+      v.customize ["modifyvm", :id, "--boot2", "disk"]
+      v.customize ["modifyvm", :id, "--chipset", "ich9"]
+      v.customize ["modifyvm", :id, "--cpuidset", "00000001", "000306a9", "00020800", "80000201", "178bfbff"]
+      v.customize ["modifyvm", :id, "--firmware", "efi"]
+      v.customize ["modifyvm", :id, "--hpet", "on"]
+      v.customize ["modifyvm", :id, "--keyboard", "usb"]
+      v.customize ["modifyvm", :id, "--memory", "2048"]
+      v.customize ["modifyvm", :id, "--mouse", "usbtablet"]
+      v.customize ["modifyvm", :id, "--vram", "9"]
     end
 
     ["vmware_fusion", "vmware_workstation"].each do |provider| 

--- a/tpl/vagrantfile-osx109-desktop.tpl
+++ b/tpl/vagrantfile-osx109-desktop.tpl
@@ -7,17 +7,17 @@ Vagrant.configure("2") do |config|
 
     config.vm.provider :virtualbox do |v, override|
       v.gui = true
-      v.customize ["modifyvm", "{{.Name}}", "--audiocontroller", "hda"]
-      v.customize ["modifyvm", "{{.Name}}", "--boot1", "dvd"]
-      v.customize ["modifyvm", "{{.Name}}", "--boot2", "disk"]
-      v.customize ["modifyvm", "{{.Name}}", "--chipset", "ich9"]
-      v.customize ["modifyvm", "{{.Name}}", "--cpuidset", "00000001", "000306a9", "00020800", "80000201", "178bfbff"]
-      v.customize ["modifyvm", "{{.Name}}", "--firmware", "efi"]
-      v.customize ["modifyvm", "{{.Name}}", "--hpet", "on"]
-      v.customize ["modifyvm", "{{.Name}}", "--keyboard", "usb"]
-      v.customize ["modifyvm", "{{.Name}}", "--memory", "2048"]
-      v.customize ["modifyvm", "{{.Name}}", "--mouse", "usbtablet"]
-      v.customize ["modifyvm", "{{.Name}}", "--vram", "9"]
+      v.customize ["modifyvm", :id, "--audiocontroller", "hda"]
+      v.customize ["modifyvm", :id, "--boot1", "dvd"]
+      v.customize ["modifyvm", :id, "--boot2", "disk"]
+      v.customize ["modifyvm", :id, "--chipset", "ich9"]
+      v.customize ["modifyvm", :id, "--cpuidset", "00000001", "000306a9", "00020800", "80000201", "178bfbff"]
+      v.customize ["modifyvm", :id, "--firmware", "efi"]
+      v.customize ["modifyvm", :id, "--hpet", "on"]
+      v.customize ["modifyvm", :id, "--keyboard", "usb"]
+      v.customize ["modifyvm", :id, "--memory", "2048"]
+      v.customize ["modifyvm", :id, "--mouse", "usbtablet"]
+      v.customize ["modifyvm", :id, "--vram", "9"]
     end
 
     ["vmware_fusion", "vmware_workstation"].each do |provider| 


### PR DESCRIPTION
There are 4 issues addressed:
- 10.7 does not boot on the existing cpuidset. The cpuidset has been changed for 10.7 to identify as an earlier CPU (C2D) than the existing one.
- The templates built into vagrant virtualbox boxes are broken because "{{.Name}}" was not expanded. This is replaced with :id instead.
- Specifying a false value for UPDATE is ignored because the comparison in the shell script does not work as intended. This is replaced with the same expression present in the debian/ubuntu update shell script.
- Installing the xcode CLI tools on 10.7 does not work because the installer fails from a verification failure. An extra option is provided to allow it to bypass the verification check, but it is assumed that the source is trustworthy.

There are some caveats with 10.7:
- Giving a 10.7 box more than 1 CPU when using Vagrant on the packer built box may cause a kernel panic in the power management module.
- 10.7's software update installer may not accept the new option when installing the xcode CLI tools if updates are disabled depending on the version of the 10.7 InstallESD used.

If these caveats should be put in a README, please identify which one.

Finally, VMWare was not available for testing. Testing occurred in Virtualbox 4.3.22 only.