### PR TITLE
Enabling the Packer vars to be set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,10 @@ endif
 PACKER_VARS_LIST = 'cm=$(CM)' 'update=$(UPDATE)' 'install_xcode_cli_tools=$(INSTALL_XCODE_CLI_TOOLS)' 'version=$(BOX_VERSION)' 'ssh_username=$(SSH_USERNAME)' 'ssh_password=$(SSH_PASSWORD)' 'install_vagrant_keys=$(INSTALL_VAGRANT_KEYS)'
 ifdef CM_VERSION
 	PACKER_VARS_LIST += 'cm_version=$(CM_VERSION)'
-else
-PACKER_VARS := $(addprefix -var , $(PACKER_VARS_LIST))
 endif
+
+PACKER_VARS := $(addprefix -var , $(PACKER_VARS_LIST))
+
 ifdef PACKER_DEBUG
 	PACKER := PACKER_LOG=1 packer --debug
 else


### PR DESCRIPTION
# Not able to customize packer build

There is an issue which stops customisation of packer variables via options in Makefile.local.

If you run virtualbox/osx1010-desktop with a simple Makefile.local  Something like:

        CM:=puppet

Packer will not receive these arguments and will continue to use those defined inside the target **.json** file.

## What have I done?

I spotted that the **PACKER_VARS** variable could never be set unless **CM_VERSION** was defined. 

This pull request adjusts to logic of the *ifdef CM_VERSION* statement so that **PACKER_VARS** is always set