### PR TITLE
Moving the autologin script to occur before update script

### DIFF
--- a/osx1010-desktop.json
+++ b/osx1010-desktop.json
@@ -118,13 +118,13 @@
       "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} sudo -E -S bash '{{ .Path }}'",
       "scripts": [
         "script/vagrant.sh",
+        "script/autologin.sh",
         "script/update.sh",
         "script/xcode-cli-tools.sh",
         "script/cmtool.sh",
         "script/vmware.sh",
         "script/parallels.sh",
-        "script/add-network-interface-detection.sh",
-        "script/autologin.sh"
+        "script/add-network-interface-detection.sh"
       ]
     }
   ],

--- a/osx1010.json
+++ b/osx1010.json
@@ -118,13 +118,13 @@
       "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} sudo -E -S bash '{{ .Path }}'",
       "scripts": [
         "script/vagrant.sh",
+        "script/autologin.sh",
         "script/update.sh",
         "script/xcode-cli-tools.sh",
         "script/cmtool.sh",
         "script/vmware.sh",
         "script/parallels.sh",
-        "script/add-network-interface-detection.sh",
-        "script/autologin.sh"
+        "script/add-network-interface-detection.sh"
       ]
     }
   ],

--- a/osx107-desktop.json
+++ b/osx107-desktop.json
@@ -119,13 +119,13 @@
       "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} sudo -E -S bash '{{ .Path }}'",
       "scripts": [
         "script/vagrant.sh",
+        "script/autologin.sh",
         "script/update.sh",
         "script/xcode-cli-tools.sh",
         "script/cmtool.sh",
         "script/vmware.sh",
         "script/parallels.sh",
-        "script/add-network-interface-detection.sh",
-        "script/autologin.sh"
+        "script/add-network-interface-detection.sh"
       ]
     }
   ],

--- a/osx107.json
+++ b/osx107.json
@@ -117,12 +117,12 @@
       "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} sudo -E -S bash '{{ .Path }}'",
       "scripts": [
         "script/vagrant.sh",
+        "script/autologin.sh",
         "script/update.sh",
         "script/xcode-cli-tools.sh",
         "script/cmtool.sh",
         "script/vmware.sh",
-        "script/add-network-interface-detection.sh",
-        "script/autologin.sh"
+        "script/add-network-interface-detection.sh"
       ]
     }
   ],

--- a/osx108-desktop.json
+++ b/osx108-desktop.json
@@ -117,13 +117,13 @@
       "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} sudo -E -S bash '{{ .Path }}'",
       "scripts": [
         "script/vagrant.sh",
+        "script/autologin.sh",
         "script/update.sh",
         "script/xcode-cli-tools.sh",
         "script/cmtool.sh",
         "script/vmware.sh",
         "script/parallels.sh",
-        "script/add-network-interface-detection.sh",
-        "script/autologin.sh"
+        "script/add-network-interface-detection.sh"
       ]
     }
   ],

--- a/osx108.json
+++ b/osx108.json
@@ -117,12 +117,12 @@
       "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} sudo -E -S bash '{{ .Path }}'",
       "scripts": [
         "script/vagrant.sh",
+        "script/autologin.sh",
         "script/update.sh",
         "script/xcode-cli-tools.sh",
         "script/cmtool.sh",
         "script/vmware.sh",
-        "script/add-network-interface-detection.sh",
-        "script/autologin.sh"
+        "script/add-network-interface-detection.sh"
       ]
     }
   ],

--- a/osx109-desktop.json
+++ b/osx109-desktop.json
@@ -118,13 +118,13 @@
       "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} sudo -E -S bash '{{ .Path }}'",
       "scripts": [
         "script/vagrant.sh",
+        "script/autologin.sh",
         "script/update.sh",
         "script/xcode-cli-tools.sh",
         "script/cmtool.sh",
         "script/vmware.sh",
         "script/parallels.sh",
-        "script/add-network-interface-detection.sh",
-        "script/autologin.sh"
+        "script/add-network-interface-detection.sh"
       ]
     }
   ],

--- a/osx109.json
+++ b/osx109.json
@@ -118,12 +118,12 @@
       "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} sudo -E -S bash '{{ .Path }}'",
       "scripts": [
         "script/vagrant.sh",
+        "script/autologin.sh",
         "script/update.sh",
         "script/xcode-cli-tools.sh",
         "script/cmtool.sh",
         "script/vmware.sh",
-        "script/add-network-interface-detection.sh",
-        "script/autologin.sh"
+        "script/add-network-interface-detection.sh"
       ]
     }
   ],


### PR DESCRIPTION
# Reordering of Provisioning Scripts

The packer provisioning script will *reboot* the vm after completion. This means that the **/private/tmp** directory will be emptied, deleting the **set_kcpassword.py** script.

Once this has happened it will not be possible to set up *autologin* for the vagrant user.

## What have I done?

I have reordered the provisioning scripts so that the **autologin** occurs before any *rebooting* of the server.