### PR TITLE
naprivs array in default user's plist should be a string, not integer

### DIFF
--- a/prepare_iso/support/pkg-postinstall
+++ b/prepare_iso/support/pkg-postinstall
@@ -38,7 +38,7 @@ $PlistBuddy -c 'Add :users:0 string '$USER'' "${ssh_group}"
 
 # Configure user with full Remote Desktop privileges
 $PlistBuddy -c 'Add :naprivs array' "$target_ds_node/users/$USER.plist"
-$PlistBuddy -c 'Add :naprivs:0 integer -1073741569' "$target_ds_node/users/$USER.plist"
+$PlistBuddy -c 'Add :naprivs:0 string -1073741569' "$target_ds_node/users/$USER.plist"
 
 
 # Pre-create user folder so veewee will have somewhere to scp configinfo to


### PR DESCRIPTION
Hi,

I've found that following command doesn't work in a VM created by these templates:

dscl -plist . readall /Users

which causes puppet to be unable to create users.

I've found the fix at https://github.com/timsutton/osx-vm-templates/commit/b0fb19cc609b1f1eab26f094761b9b803011bbf0 and it seems to work (at least at 10.9).

Petr.