### PR TITLE
Allow disconnect in the macos template to fix vmware

### DIFF
--- a/macos.json
+++ b/macos.json
@@ -142,6 +142,7 @@
         "SSH_PASSWORD={{ user `ssh_password` }}"
       ],
       "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} sudo -E -S bash '{{ .Path }}'",
+      "expect_disconnect": true,
       "scripts": [
         "script/minimize.sh"
       ],
@@ -168,4 +169,3 @@
     "vmware_guest_os_type": "darwin15-64"
   }
 }
-


### PR DESCRIPTION
This fixes a failure during the disk shrink on vmware.

Signed-off-by: Tim Smith <tsmith@chef.io>